### PR TITLE
feat: geoserver image upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,8 +58,3 @@ fi
 USER user
 
 ENTRYPOINT ["/bin/bash", "/scripts/cert-start.sh"]
-
-
-
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,21 +2,11 @@ ARG GEOSERVER_BASE_IMAGE
 
 FROM ${GEOSERVER_BASE_IMAGE}
 
-ARG GEOSERVER_VERSION
-ARG OTEL_VERSION
-ARG LOG4J_VERSION
-ARG JMX_PROMETHEUS_VERSION
-
 ENV OTEL_SERVICE_NAME=geoserver
 ENV RUN_AS_ROOT=true
 ENV OTEL_LOGS_EXPORTER=none
 
 USER root
-
-RUN wget --directory-prefix=/otel https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/${OTEL_VERSION}/opentelemetry-javaagent.jar \
-    && wget --directory-prefix=${CATALINA_HOME}/webapps/geoserver/WEB-INF/lib https://search.maven.org/remotecontent?filepath=org/apache/logging/log4j/log4j-layout-template-json/${LOG4J_VERSION}/log4j-layout-template-json-${LOG4J_VERSION}.jar \
-    && wget --directory-prefix=/jmx https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/${JMX_PROMETHEUS_VERSION}/jmx_prometheus_javaagent-${JMX_PROMETHEUS_VERSION}.jar \
-    && mv /jmx/jmx_prometheus_javaagent-${JMX_PROMETHEUS_VERSION}.jar /jmx/jmx_prometheus_javaagent.jar
 
 RUN mkdir -p "${GEOSERVER_DATA_DIR}" \
     "${CERT_DIR}" \
@@ -38,22 +28,9 @@ RUN sed -i 's/chmod o+rw "\${CERT_DIR}";gwc_file_perms ;find \${CATALINA_HOME}\/
 
 RUN mkdir /.postgresql && chmod g+w /.postgresql
 
-COPY jmx_config.yaml /jmx/config.yaml
 COPY cert-start.sh /scripts/cert-start.sh
 
 RUN useradd -ms /bin/bash user && usermod -a -G root user
-
-RUN echo ${GEOSERVER_VERSION} 
-RUN echo ${GEOSERVER_VERSION} | awk '{print ($1 >= 2.27)}'
-# Install GeoServer ogcapi-features-plugin. Available in GeoServer 2.27 and later.
-# This plugin is required for the GeoServer to support OGC API Features.
-# The plugin is not included in the GeoServer base image by default (right to May 8th 2025).
-RUN if [ -n "${GEOSERVER_VERSION}" ] && [ "$(echo ${GEOSERVER_VERSION} | awk '{print ($1 >= 2.27)}')" -eq 1 ]; then \
-    mkdir /tmp/ogcfeaturesplugin && wget --directory-prefix=/tmp/ogcfeaturesplugin https://build.geoserver.org/geoserver/${GEOSERVER_VERSION}.x/ext-latest/geoserver-${GEOSERVER_VERSION}-SNAPSHOT-ogcapi-features-plugin.zip \
-    && unzip /tmp/ogcfeaturesplugin/geoserver-${GEOSERVER_VERSION}-SNAPSHOT-ogcapi-features-plugin.zip -d /tmp/ogcfeaturesplugin \
-    && cp -r /tmp/ogcfeaturesplugin/* ${CATALINA_HOME}/webapps/geoserver/WEB-INF/lib \
-    && rm -rf /tmp/ogcfeaturesplugin; \
-fi
 
 USER user
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN chmod -R g=u ${CATALINA_HOME} /opt /usr/local/tomcat /settings /etc/certs \
     /scripts /tmp/ /home /community_plugins/ \
     ${GEOSERVER_HOME} /usr/share/fonts/
 
-RUN sed -i 's/chmod o+rw \"\${CERT_DIR}\"\;gwc_file_perms \;chmod 400 \"\${CATALINA_HOME}\"\/conf\/\*/ /g' /scripts/entrypoint.sh
+RUN sed -i 's/chmod o+rw "\${CERT_DIR}";gwc_file_perms ;find \${CATALINA_HOME}\/conf\/ -type f -exec chmod 400 {} \\;//g' /scripts/entrypoint.sh
 
 RUN mkdir /.postgresql && chmod g+w /.postgresql
 

--- a/README.md
+++ b/README.md
@@ -16,63 +16,72 @@ Therefore we cant change the owner of the folder to the random generated user wh
 ## Run the script
 
 **DON'T FORGET TO RUN**
+
 ```sh
 npm i
 ```
 
 Running the script
+
 ```
 npx zx index.mjs
 ```
 
 ## Configurable options
-| ENV                          | Default Value                               | Description                                                         | mandatory? |
-|------------------------------|---------------------------------------------|---------------------------------------------------------------------|------------|
-| IMAGE_REPO                   |                                             | The name of the docker image                                        | yes        |
-| GEOSERVER_VERSION            |                                             | The `kartoza/geoserver` version                                     | yes        |
-| WORK_DIR                     | /tmp/geoserver                              | The folder where the script clones the `kartoza/geoserver` git repo | no         |
-| IMAGE_DOCKER_REGISTRY        |                                             | If set it will tag image with the registry prefix                   | no         |
-| POSTGRES_ENABLE_SSL_AUTH     |                                             | If set it will load postgres ssl auth certs to the required location| no         |
-| POSTGRES_CERTS_MOUNT_PATH    |                                             | The location where the postgres certs are mounted                   |            |
-| ADD_ROOT_CERTS | | enable adding certs to geoserver
-| ROOT_CERTS_PATH | | path to load the certs from
-| TELEMETRY_TRACING_ENABLED||set to true if you want the app to be traced
-| TELEMETRY_METRICS_ENABLED||set to true if you want JVM metrics exported for prometheus. port is 12345
-| LOG4J_VERSION ||used for json logging, defaults to 2.17.2
+
+| ENV                       | Default Value  | Description                                                          | mandatory? |
+| ------------------------- | -------------- | -------------------------------------------------------------------- | ---------- |
+| IMAGE_REPO                |                | The name of the docker image                                         | yes        |
+| GEOSERVER_VERSION         |                | The `kartoza/geoserver` version                                      | yes        |
+| WORK_DIR                  | /tmp/geoserver | The folder where the script clones the `kartoza/geoserver` git repo  | no         |
+| IMAGE_DOCKER_REGISTRY     |                | If set it will tag image with the registry prefix                    | no         |
+| POSTGRES_ENABLE_SSL_AUTH  |                | If set it will load postgres ssl auth certs to the required location | no         |
+| POSTGRES_CERTS_MOUNT_PATH |                | The location where the postgres certs are mounted                    |            |
+| ADD_ROOT_CERTS            |                | enable adding certs to geoserver                                     |
+| ROOT_CERTS_PATH           |                | path to load the certs from                                          |
+
+## Telemetry and Metrics
+
+Telemetry and metrics are now part of `kartoza/docker-geoserver`. Read more about it [here](https://github.com/kartoza/docker-geoserver/?tab=readme-ov-file#opentelemetry-and-prometheus-jmx-metrics-support)
 
 ## Postgres SSL authentication
 
 The required file in order to connect to postgres using ssl mode are as follows:
-- `postgresql.crt`
-- `postgresql.pk8`
-- `root.ca`
+
+-   `postgresql.crt`
+-   `postgresql.pk8`
+-   `root.ca`
 
 To convert a standard private key to PKCS8 you can use the following openssl command:
 
 `openssl pkcs8 -topk8 -inform PEM -outform DER -in postgresql.key -out postgresql.pk8 -nocrypt`
-  
-  
+
 # helm
+
 This repo contains a helm chart to deploy geoserver with reloading configuration to opeshift.
 
 ## Why?
+
 Geoserver by nature is a monolithic project that is built to run on VM or a physical machine.
 Because we want it to run on k8s, we added a sidecar that enables geoserver to be deployed to k8s without a persistent volume.
 
 ## How does it work?
+
 When a new geoserver pod is starting, an init-container that runs the image will download the datadir from S3 for the first time, so geoserver has an initial configuration.
 After the init container has finished it job, the geoserver image will start, and a sidecar that will check periodically for changes in S3, and if it detects one, it will download the new one, and apply it to the Geoserver image.
 
 ## Logging
-- for custom geoserver logging define your logging schema and place it in `/data_dir/logs/custom_logging.xml` it is possible to log in json format using the `JsonTemplateLayout` [read more](https://logging.apache.org/log4j/2.x/manual/json-template-layout.html)
 
-- you can set the used logging schema through the geoserver UI under Global-Settings -> Logging Profile or specify it in `/data_dir/logging.xml`
+-   for custom geoserver logging define your logging schema and place it in `/data_dir/logs/custom_logging.xml` it is possible to log in json format using the `JsonTemplateLayout` [read more](https://logging.apache.org/log4j/2.x/manual/json-template-layout.html)
 
-- in the UI you can also define your wanted requests logging strategy
+-   you can set the used logging schema through the geoserver UI under Global-Settings -> Logging Profile or specify it in `/data_dir/logging.xml`
 
+-   in the UI you can also define your wanted requests logging strategy
 
 ## Installation
+
 set the values as you please, and run:
+
 ```bash
   cd helm
   helm install geoserver .

--- a/cert-start.sh
+++ b/cert-start.sh
@@ -10,16 +10,6 @@ then
   chmod 400 $POSTGRES_CERTIFICATES_PATH/*.pk8
 fi
 
-if [ "$TELEMETRY_TRACING_ENABLED" = "true" ]
-then
-  export JAVA_OPTS="${JAVA_OPTS} -javaagent:/otel/opentelemetry-javaagent.jar"
-fi
-
-if [ "$TELEMETRY_METRICS_ENABLED" = "true" ]
-then
-  export JAVA_OPTS="${JAVA_OPTS} -javaagent:/jmx/jmx_prometheus_javaagent.jar=12345:/jmx/config.yaml"
-fi
-
 if [ "$ADD_ROOT_CERTS" = "true" ]
 then
   FILES="${ROOT_CERTS_PATH}/*"

--- a/index.mjs
+++ b/index.mjs
@@ -18,8 +18,6 @@ try {
 		.slice(0, 2)
 		.join('.');
 
-	console.log(geoserverMajorMinorVersion);
-
 	await $`docker build -q --build-arg OTEL_VERSION=${OTEL_VERSION} --build-arg LOG4J_VERSION=${LOG4J_VERSION} --build-arg JMX_PROMETHEUS_VERSION=${JMX_PROMETHEUS_VERSION} --build-arg GEOSERVER_BASE_IMAGE=${geoserverBaseImageName} --build-arg GEOSERVER_VERSION=${geoserverMajorMinorVersion} -f Dockerfile -t ${imageName} .`;
 
 	console.log(chalk.blue('Builds Openshift ready Geoserver Image'));

--- a/index.mjs
+++ b/index.mjs
@@ -1,34 +1,39 @@
 #!/usr/bin/env zx
 
 const {
-  GEOSERVER_VERSION = '2.26.0',
-  IMAGE_DOCKER_REGISTRY,
-  IMAGE_REPO = 'geoserver',
-  WORK_DIR = '/tmp/geoserver',
-  OTEL_VERSION = 'v2.9.0',
-  LOG4J_VERSION = '2.17.2',
-  JMX_PROMETHEUS_VERSION = '0.19.0',
+	GEOSERVER_VERSION = '2.27.0',
+	IMAGE_DOCKER_REGISTRY,
+	IMAGE_REPO = 'geoserver',
+	WORK_DIR = '/tmp/geoserver',
+	OTEL_VERSION = 'v2.9.0',
+	LOG4J_VERSION = '2.17.2',
+	JMX_PROMETHEUS_VERSION = '0.19.0',
 } = process.env;
 
 try {
-  const packageVersion = await require('./package.json').version;
-  const imageName = `${IMAGE_REPO}:v${packageVersion}-${GEOSERVER_VERSION}`;
-  const geoserverBaseImageName = `kartoza/geoserver:${GEOSERVER_VERSION}`;
+	const packageVersion = await require('./package.json').version;
+	const imageName = `${IMAGE_REPO}:v${packageVersion}-${GEOSERVER_VERSION}`;
+	const geoserverBaseImageName = `kartoza/geoserver:${GEOSERVER_VERSION}`;
+	const geoserverMajorMinorVersion = GEOSERVER_VERSION.split('.')
+		.slice(0, 2)
+		.join('.');
 
-  await $`docker build -q --build-arg OTEL_VERSION=${OTEL_VERSION} --build-arg LOG4J_VERSION=${LOG4J_VERSION} --build-arg JMX_PROMETHEUS_VERSION=${JMX_PROMETHEUS_VERSION} --build-arg GEOSERVER_BASE_IMAGE=${geoserverBaseImageName} -f Dockerfile -t ${imageName} .`;
+	console.log(geoserverMajorMinorVersion);
 
-  console.log(chalk.blue('Builds Openshift ready Geoserver Image'));
-  console.log(IMAGE_DOCKER_REGISTRY);
+	await $`docker build -q --build-arg OTEL_VERSION=${OTEL_VERSION} --build-arg LOG4J_VERSION=${LOG4J_VERSION} --build-arg JMX_PROMETHEUS_VERSION=${JMX_PROMETHEUS_VERSION} --build-arg GEOSERVER_BASE_IMAGE=${geoserverBaseImageName} --build-arg GEOSERVER_VERSION=${geoserverMajorMinorVersion} -f Dockerfile -t ${imageName} .`;
 
-  if (IMAGE_DOCKER_REGISTRY) {
-    const taggedImageName = `${IMAGE_DOCKER_REGISTRY}/${imageName}`;
-    await $`docker tag ${imageName} ${taggedImageName}`;
-    console.log(chalk.blue(`Tagged Docker Image as ${taggedImageName}`));
-  }
-  console.log(chalk.magenta('We did it!! 🐧🐧🐧🐧🐧'));
+	console.log(chalk.blue('Builds Openshift ready Geoserver Image'));
+	console.log(IMAGE_DOCKER_REGISTRY);
+
+	if (IMAGE_DOCKER_REGISTRY) {
+		const taggedImageName = `${IMAGE_DOCKER_REGISTRY}/${imageName}`;
+		await $`docker tag ${imageName} ${taggedImageName}`;
+		console.log(chalk.blue(`Tagged Docker Image as ${taggedImageName}`));
+	}
+	console.log(chalk.magenta('We did it!! 🐧🐧🐧🐧🐧'));
 } catch (e) {
-  console.log(chalk.red('Oh no! 😢'));
-  console.error(e);
+	console.log(chalk.red('Oh no! 😢'));
+	console.error(e);
 } finally {
-  await $`rm -rf ${WORK_DIR}`;
+	await $`rm -rf ${WORK_DIR}`;
 }

--- a/index.mjs
+++ b/index.mjs
@@ -12,7 +12,7 @@ try {
 	const imageName = `${IMAGE_REPO}:v${packageVersion}-${GEOSERVER_VERSION}`;
 	const geoserverBaseImageName = `kartoza/geoserver:${GEOSERVER_VERSION}`;
 
-	await $`docker build -q --build-arg GEOSERVER_BASE_IMAGE=${geoserverBaseImageName} --build-arg GEOSERVER_VERSION=${geoserverMajorMinorVersion} -f Dockerfile -t ${imageName} .`;
+	await $`docker build -q --build-arg GEOSERVER_BASE_IMAGE=${geoserverBaseImageName} -f Dockerfile -t ${imageName} .`;
 
 	console.log(chalk.blue('Builds Openshift ready Geoserver Image'));
 	console.log(IMAGE_DOCKER_REGISTRY);

--- a/index.mjs
+++ b/index.mjs
@@ -11,9 +11,6 @@ try {
 	const packageVersion = await require('./package.json').version;
 	const imageName = `${IMAGE_REPO}:v${packageVersion}-${GEOSERVER_VERSION}`;
 	const geoserverBaseImageName = `kartoza/geoserver:${GEOSERVER_VERSION}`;
-	const geoserverMajorMinorVersion = GEOSERVER_VERSION.split('.')
-		.slice(0, 2)
-		.join('.');
 
 	await $`docker build -q --build-arg GEOSERVER_BASE_IMAGE=${geoserverBaseImageName} --build-arg GEOSERVER_VERSION=${geoserverMajorMinorVersion} -f Dockerfile -t ${imageName} .`;
 

--- a/index.mjs
+++ b/index.mjs
@@ -1,13 +1,10 @@
 #!/usr/bin/env zx
 
 const {
-	GEOSERVER_VERSION = '2.27.0',
+	GEOSERVER_VERSION = '2.27.1--v2025.07.17',
 	IMAGE_DOCKER_REGISTRY,
 	IMAGE_REPO = 'geoserver',
 	WORK_DIR = '/tmp/geoserver',
-	OTEL_VERSION = 'v2.9.0',
-	LOG4J_VERSION = '2.17.2',
-	JMX_PROMETHEUS_VERSION = '0.19.0',
 } = process.env;
 
 try {
@@ -18,7 +15,7 @@ try {
 		.slice(0, 2)
 		.join('.');
 
-	await $`docker build -q --build-arg OTEL_VERSION=${OTEL_VERSION} --build-arg LOG4J_VERSION=${LOG4J_VERSION} --build-arg JMX_PROMETHEUS_VERSION=${JMX_PROMETHEUS_VERSION} --build-arg GEOSERVER_BASE_IMAGE=${geoserverBaseImageName} --build-arg GEOSERVER_VERSION=${geoserverMajorMinorVersion} -f Dockerfile -t ${imageName} .`;
+	await $`docker build -q --build-arg GEOSERVER_BASE_IMAGE=${geoserverBaseImageName} --build-arg GEOSERVER_VERSION=${geoserverMajorMinorVersion} -f Dockerfile -t ${imageName} .`;
 
 	console.log(chalk.blue('Builds Openshift ready Geoserver Image'));
 	console.log(IMAGE_DOCKER_REGISTRY);

--- a/jmx_config.yaml
+++ b/jmx_config.yaml
@@ -1,2 +1,0 @@
-rules:
-- pattern: ".*"


### PR DESCRIPTION
* upgrade base image
* Removed the install of promethus agent, opentelemetry agent and log4j ecs layout as they are now part of `kartoza/geoserver` images